### PR TITLE
Remove comparable from Validatable?

### DIFF
--- a/documentation.json
+++ b/documentation.json
@@ -8,8 +8,7 @@
         "name": "Validatable",
         "comment": " You have to wrap every value of your form inside this type. For\nexample, if your model looked something like\n\n    type alias FormerModel =\n        { username : String\n        , email : String\n        , password : String\n        , passwordCopy : String\n        }\n\nyou have to change it to\n\n    type alias Model =\n        { username : Validatable String String\n        , email : Validatable String String\n        , password : Validatable String String\n        , passwordCopy : Validatable String String\n        }\n\n",
         "args": [
-          "a",
-          "comparable"
+          "a"
         ],
         "cases": []
       }
@@ -18,107 +17,107 @@
       {
         "name": "addErrors",
         "comment": " Add the given set of validation errors. This makes every value\nwhich is not empty invalid. You can use this function if you need to\nshow validations to the user which can only be performed on the server,\nfor example checking if a username is still available.\n\n**Note:** If the set is empty, we do not change the state of the value.\n\n",
-        "type": "Set.Set comparable -> Validate.Validatable a comparable -> Validate.Validatable a comparable"
+        "type": "Set.Set String -> Validate.Validatable a -> Validate.Validatable a"
       },
       {
         "name": "atLeast",
         "comment": " Check if the string value is at least 6 characters long.\n",
-        "type": "Int -> comparable -> Validate.Validatable String comparable -> Validate.Validatable String comparable"
+        "type": "Int -> String -> Validate.Validatable String -> Validate.Validatable String"
       },
       {
         "name": "consistsOfLetters",
         "comment": " Check if the string value only consists of letters.\n",
-        "type": "comparable -> Validate.Validatable String comparable -> Validate.Validatable String comparable"
+        "type": "String -> Validate.Validatable String -> Validate.Validatable String"
       },
       {
         "name": "empty",
         "comment": " Use this to initialize your values:\n\n    init : Model\n    init =\n        { username = empty\n        , email = empty\n        , pasword = empty\n        , passwordCopy = empty\n        }\n\n",
-        "type": "Validate.Validatable a comparable"
+        "type": "Validate.Validatable a"
       },
       {
         "name": "equals",
         "comment": " Given a reference value, check if the value equals it.\n",
-        "type": "a -> comparable -> Validate.Validatable a comparable -> Validate.Validatable a comparable"
+        "type": "a -> String -> Validate.Validatable a -> Validate.Validatable a"
       },
       {
         "name": "errors",
         "comment": " Return all validation errors if the value has been tried to be\nvalidated at least once.\n",
-        "type": "Validate.Validatable a comparable -> Maybe.Maybe (Set.Set comparable)"
+        "type": "Validate.Validatable a -> Maybe.Maybe (Set.Set String)"
       },
       {
         "name": "isEmail",
         "comment": " Check if the string value is a proper email address.\n",
-        "type": "comparable -> Validate.Validatable String comparable -> Validate.Validatable String comparable"
+        "type": "String -> Validate.Validatable String -> Validate.Validatable String"
       },
       {
         "name": "isFloat",
         "comment": " Try to cast a `String` to a `Float`.\n",
-        "type": "comparable -> String -> Validate.Validatable Float comparable"
+        "type": "String -> String -> Validate.Validatable Float"
       },
       {
         "name": "isInt",
         "comment": " Try to cast a `String` to an `Int`.\n",
-        "type": "comparable -> String -> Validate.Validatable Int comparable"
+        "type": "String -> String -> Validate.Validatable Int"
       },
       {
         "name": "isNotEmpty",
         "comment": " Check if the string value is non-empty. The first argument is the\nerror which is recorded if the value is empty.\n\n    (unchecked \"I am not empty!\"\n        |> isNotEmpty \"the value must not be empty\"\n        |> validValue\n    )\n        == Just \"I am not empty!\"\n\n    (unchecked \"\"\n        |> isNotEmpty \"the value must not be empty\"\n        |> errors\n        |> Maybe.map toList\n    )\n        == Just [ \"the value must not be empty\" ]\n\n",
-        "type": "comparable -> Validate.Validatable String comparable -> Validate.Validatable String comparable"
+        "type": "String -> Validate.Validatable String -> Validate.Validatable String"
       },
       {
         "name": "map",
         "comment": " Apply the given function on the actual value.\n",
-        "type": "(a -> b) -> Validate.Validatable a comparable -> Validate.Validatable b comparable"
+        "type": "(a -> b) -> Validate.Validatable a -> Validate.Validatable b"
       },
       {
         "name": "mapErrors",
         "comment": " Apply the given function on the error values.\n",
-        "type": "(comparableA -> comparableB) -> Validate.Validatable a comparableA -> Validate.Validatable a comparableB"
+        "type": "(String -> String) -> Validate.Validatable a -> Validate.Validatable a"
       },
       {
         "name": "maybe",
         "comment": " Apply the validator on maybe values. If the value is `Nothing`, it\nis left unchanged. This is usefull if you need to validate optional\narguments, for example\n\n    nickname : Validatable (Maybe String) String\n    nickname =\n        valid Nothing\n\n    (nickname\n        |> maybe (consistsOfLetters \"nickname must consist of letters only\")\n        |> validValue\n    )\n        == Just Nothing\n\n\n    invalidNickname : Validatable (Maybe String) String\n    invalidNickname =\n        unchecked (Just \"123\")\n\n    (invalidNickname\n        |> maybe (consistsOfLetters \"nickname must consist of letters only\")\n        |> errors\n        |> Set.toList\n    )\n        == Just [ \"nickname must consist of letters only\" ]\n\n",
-        "type": "(Validate.Validatable a comparable -> Validate.Validatable a comparable) -> Validate.Validatable (Maybe.Maybe a) comparable -> Validate.Validatable (Maybe.Maybe a) comparable"
+        "type": "(Validate.Validatable a -> Validate.Validatable a) -> Validate.Validatable (Maybe.Maybe a) -> Validate.Validatable (Maybe.Maybe a)"
       },
       {
         "name": "rawValue",
         "comment": " **I am not sure if it is a good idea to have this function at all,\nso it may be removed in the future.**\n\nReturn the value, no matter if it is valid or not.\n\n**Note:** If the value is in an invalid state, there may not be a raw\nvalue anymore.\n\n**Note:** Don't use this to extract the value for submitting the form.\nUse `validValue` instead, to ensure at compile time that you only submit\nvalid values.\n\n",
-        "type": "Validate.Validatable a comparable -> Maybe.Maybe a"
+        "type": "Validate.Validatable a -> Maybe.Maybe a"
       },
       {
         "name": "satisfies",
         "comment": " Check if the value satisfies the condition. If not add the provided\nerror to the list of errors.\n\n**Note:** If the value was in an invalid state before and satisfies the\ncondition we drop the previous errors and return a valid value.\n\n",
-        "type": "(a -> Bool) -> comparable -> Validate.Validatable a comparable -> Validate.Validatable a comparable"
+        "type": "(a -> Bool) -> String -> Validate.Validatable a -> Validate.Validatable a"
       },
       {
         "name": "try",
         "comment": " Run the provided computation which might result in an error. If it\nsucceeds, we get a valid value, if it fails we get an invalid state with\nthe given errors. So, you can do something like this:\n\n    (\"not a number\"\n        |> try String.toInt (\\err -> \"You must provide an integer: \" ++ err)\n        |> errors\n        |> Maybe.map toList\n    )\n        == Just [ \"You must provide an integer: could not convert ...\" ]\n\n",
-        "type": "(a -> Result.Result err b) -> (err -> comparable) -> a -> Validate.Validatable b comparable"
+        "type": "(a -> Result.Result err b) -> (err -> String) -> a -> Validate.Validatable b"
       },
       {
         "name": "uncheck",
         "comment": " Set the value to unchecked if possible.\n",
-        "type": "Validate.Validatable a comparable -> Validate.Validatable a comparable"
+        "type": "Validate.Validatable a -> Validate.Validatable a"
       },
       {
         "name": "unchecked",
         "comment": " Use this to update a value in your model in reaction to user input:\n\n    update : Msg -> Model -> Model\n    update msg model =\n        case msg of\n            SetUsername string ->\n                { model | username = unchecked string }\n\n            ...\n\n",
-        "type": "a -> Validate.Validatable a comparable"
+        "type": "a -> Validate.Validatable a"
       },
       {
         "name": "valid",
         "comment": " Create a valid value. Usefull for initializing with a default\nvalue.\n",
-        "type": "a -> Validate.Validatable a comparable"
+        "type": "a -> Validate.Validatable a"
       },
       {
         "name": "validValue",
         "comment": " Return the actual value if it has been successfully validated at\nleast once.\n",
-        "type": "Validate.Validatable a comparable -> Maybe.Maybe a"
+        "type": "Validate.Validatable a -> Maybe.Maybe a"
       },
       {
         "name": "with",
         "comment": " Apply a validation only if another value was successfully validated.\nThis unchecks the value if the provided value was not valid. For\nexample, you can do something like this\n\n    password : Validatable String String\n\n    passwordCopy : Validatable String String\n    passwordCopy =\n        oldPasswordCopy\n            |> Validate.with password\n                (\\validPassword ->\n                    Validate.equals validPassword \"Both passwords have to match up.\"\n                )\n\n",
-        "type": "Validate.Validatable a comparable -> (a -> Validate.Validatable b comparable -> Validate.Validatable b comparable) -> Validate.Validatable b comparable -> Validate.Validatable b comparable"
+        "type": "Validate.Validatable a -> (a -> Validate.Validatable b -> Validate.Validatable b) -> Validate.Validatable b -> Validate.Validatable b"
       }
     ],
     "generated-with-elm-version": "0.18.0"

--- a/src/Validate.elm
+++ b/src/Validate.elm
@@ -139,18 +139,18 @@ example, if your model looked something like
 you have to change it to
 
     type alias Model =
-        { username : Validatable String String
-        , email : Validatable String String
-        , password : Validatable String String
-        , passwordCopy : Validatable String String
+        { username : Validatable String
+        , email : Validatable String
+        , password : Validatable String
+        , passwordCopy : Validatable String
         }
 
 -}
-type Validatable a comparable
+type Validatable a
     = Empty
     | Unchecked a
     | Valid a
-    | Invalid (Maybe a) (Set comparable)
+    | Invalid (Maybe a) (Set String)
 
 
 {-| Use this to initialize your values:
@@ -164,7 +164,7 @@ type Validatable a comparable
         }
 
 -}
-empty : Validatable a comparable
+empty : Validatable a
 empty =
     Empty
 
@@ -180,14 +180,14 @@ empty =
             ...
 
 -}
-unchecked : a -> Validatable a comparable
+unchecked : a -> Validatable a
 unchecked a =
     Unchecked a
 
 
 {-| Set the value to unchecked if possible.
 -}
-uncheck : Validatable a comparable -> Validatable a comparable
+uncheck : Validatable a -> Validatable a
 uncheck value =
     case value of
         Empty ->
@@ -212,7 +212,7 @@ uncheck value =
 {-| Create a valid value. Usefull for initializing with a default
 value.
 -}
-valid : a -> Validatable a comparable
+valid : a -> Validatable a
 valid a =
     Valid a
 
@@ -220,7 +220,7 @@ valid a =
 {-| Return the actual value if it has been successfully validated at
 least once.
 -}
-validValue : Validatable a comparable -> Maybe a
+validValue : Validatable a -> Maybe a
 validValue value =
     case value of
         Empty ->
@@ -239,7 +239,7 @@ validValue value =
 {-| Return all validation errors if the value has been tried to be
 validated at least once.
 -}
-errors : Validatable a comparable -> Maybe (Set comparable)
+errors : Validatable a -> Maybe (Set String)
 errors value =
     case value of
         Empty ->
@@ -268,7 +268,7 @@ Use `validValue` instead, to ensure at compile time that you only submit
 valid values.
 
 -}
-rawValue : Validatable a comparable -> Maybe a
+rawValue : Validatable a -> Maybe a
 rawValue value =
     case value of
         Empty ->
@@ -301,21 +301,21 @@ error which is recorded if the value is empty.
         == Just [ "the value must not be empty" ]
 
 -}
-isNotEmpty : comparable -> Validatable String comparable -> Validatable String comparable
+isNotEmpty : String -> Validatable String -> Validatable String
 isNotEmpty error value =
     value |> satisfies (not << String.isEmpty) error
 
 
 {-| Check if the string value is at least 6 characters long.
 -}
-atLeast : Int -> comparable -> Validatable String comparable -> Validatable String comparable
+atLeast : Int -> String -> Validatable String -> Validatable String
 atLeast minimalLength error value =
     value |> satisfies (\string -> minimalLength <= String.length string) error
 
 
 {-| Check if the string value only consists of letters.
 -}
-consistsOfLetters : comparable -> Validatable String comparable -> Validatable String comparable
+consistsOfLetters : String -> Validatable String -> Validatable String
 consistsOfLetters error value =
     let
         onlyLetters string =
@@ -329,7 +329,7 @@ consistsOfLetters error value =
 
 {-| Check if the string value is a proper email address.
 -}
-isEmail : comparable -> Validatable String comparable -> Validatable String comparable
+isEmail : String -> Validatable String -> Validatable String
 isEmail error value =
     let
         validEmail string =
@@ -344,7 +344,7 @@ isEmail error value =
 
 {-| Try to cast a `String` to an `Int`.
 -}
-isInt : comparable -> String -> Validatable Int comparable
+isInt : String -> String -> Validatable Int
 isInt error input =
     input
         |> try String.toInt (\_ -> error)
@@ -352,7 +352,7 @@ isInt error input =
 
 {-| Try to cast a `String` to a `Float`.
 -}
-isFloat : comparable -> String -> Validatable Float comparable
+isFloat : String -> String -> Validatable Float
 isFloat error input =
     input
         |> try String.toFloat (\_ -> error)
@@ -370,7 +370,7 @@ the given errors. So, you can do something like this:
         == Just [ "You must provide an integer: could not convert ..." ]
 
 -}
-try : (a -> Result err b) -> (err -> comparable) -> a -> Validatable b comparable
+try : (a -> Result err b) -> (err -> String) -> a -> Validatable b
 try cast error value =
     case cast value of
         Err err ->
@@ -387,7 +387,7 @@ error to the list of errors.
 condition we drop the previous errors and return a valid value.
 
 -}
-satisfies : (a -> Bool) -> comparable -> Validatable a comparable -> Validatable a comparable
+satisfies : (a -> Bool) -> String -> Validatable a -> Validatable a
 satisfies condition error value =
     case value of
         Empty ->
@@ -421,9 +421,9 @@ satisfies condition error value =
 -}
 equals :
     a
-    -> comparable
-    -> Validatable a comparable
-    -> Validatable a comparable
+    -> String
+    -> Validatable a
+    -> Validatable a
 equals reference error value =
     value |> satisfies ((==) reference) error
 
@@ -436,7 +436,7 @@ for example checking if a username is still available.
 **Note:** If the set is empty, we do not change the state of the value.
 
 -}
-addErrors : Set comparable -> Validatable a comparable -> Validatable a comparable
+addErrors : Set String -> Validatable a -> Validatable a
 addErrors validationErrors value =
     if validationErrors |> Set.isEmpty then
         value
@@ -457,7 +457,7 @@ addErrors validationErrors value =
 
 {-| Apply the given function on the actual value.
 -}
-map : (a -> b) -> Validatable a comparable -> Validatable b comparable
+map : (a -> b) -> Validatable a -> Validatable b
 map f value =
     case value of
         Empty ->
@@ -476,9 +476,9 @@ map f value =
 {-| Apply the given function on the error values.
 -}
 mapErrors :
-    (comparableA -> comparableB)
-    -> Validatable a comparableA
-    -> Validatable a comparableB
+    (String -> String)
+    -> Validatable a
+    -> Validatable a
 mapErrors f value =
     case value of
         Empty ->
@@ -522,9 +522,9 @@ arguments, for example
 
 -}
 maybe :
-    (Validatable a comparable -> Validatable a comparable)
-    -> Validatable (Maybe a) comparable
-    -> Validatable (Maybe a) comparable
+    (Validatable a -> Validatable a)
+    -> Validatable (Maybe a)
+    -> Validatable (Maybe a)
 maybe validator maybeValue =
     case maybeValue of
         Unchecked (Just a) ->
@@ -562,10 +562,10 @@ example, you can do something like this
 
 -}
 with :
-    Validatable a comparable
-    -> (a -> Validatable b comparable -> Validatable b comparable)
-    -> Validatable b comparable
-    -> Validatable b comparable
+    Validatable a
+    -> (a -> Validatable b -> Validatable b)
+    -> Validatable b
+    -> Validatable b
 with reference validator value =
     case reference of
         Empty ->


### PR DESCRIPTION
It seems to me that you'd always want the error to be a `String`, so this PR replaces `comparable` with a hardcoded `String`, to simplify usage of `Validatable`.

I definitly understand that there might be a great reason behind having it as `comparable`, which is why I created this PR (I was going to start an issue, but since it's an easy change, I decided it's nicer to you if I bring the code as well). What is the reason for having a `comparable`?
